### PR TITLE
Adding streaming for download of large files

### DIFF
--- a/src/main/java/com/jasonwjones/pbcs/PbcsClientImpl.java
+++ b/src/main/java/com/jasonwjones/pbcs/PbcsClientImpl.java
@@ -83,6 +83,16 @@ public class PbcsClientImpl implements PbcsClient {
 		throw new UnsupportedOperationException("Operation not supported yet");
 	}
 
+	@Override
+	public File downloadFileViaStream(String filename) throws PbcsClientException {
+		return interopClient.downloadFileViaStream(filename);
+	}
+
+	@Override
+	public File downloadFileViaStream(String filename, String localFilename) {
+		return interopClient.downloadFileViaStream(filename, localFilename);
+	}
+
 //	@Override
 //	public MaintenanceWindow getMaintenanceWindow() {
 //		return interopClient.getMaintenanceWindow();

--- a/src/main/java/com/jasonwjones/pbcs/interop/InteropClient.java
+++ b/src/main/java/com/jasonwjones/pbcs/interop/InteropClient.java
@@ -35,6 +35,20 @@ public interface InteropClient {
 	public File downloadFile(String filename) throws PbcsClientException;
 
 	public File downloadFile(String filename, String localFilename);
+	/**
+	 * This is usefull for downloading large files - whole content is streamed to disk
+	 * @param filename remote filename in cloud
+	 * @return
+	 * @throws PbcsClientException
+	 */
+	public File downloadFileViaStream(String filename) throws PbcsClientException;
+	/**
+	 * This is usefull for downloading large files - whole content is streamed to disk
+	 * @param filename remote filename in cloud
+	 * @param localFilename filename on disk
+	 * @return
+	 */
+	public File downloadFileViaStream(String filename, String localFilename);
 
 	/**
 	 * Uploads a file to PBCS so that it can be imported.


### PR DESCRIPTION
You cant download large files. We had to download file of circa 600 MB and it was killing our JVM memory and usually ended with OoSpace...
This way (via stream methods) any size of file can be downloaded.